### PR TITLE
Fix middleware list formatting

### DIFF
--- a/learningplatform_backend/settings.py
+++ b/learningplatform_backend/settings.py
@@ -97,12 +97,11 @@ INSTALLED_APPS = [
 MIDDLEWARE = [
     "django.middleware.security.SecurityMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
-    "django.middleware.common.CommonMiddleware",iddleware",
+    "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
-    "django.contrib.messages.middleware.MessageMiddleware",e",
+    "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    # Consolidated middlewareacking.XFrameOptionsMiddleware",
     "learningplatform_backend.middleware.middleware.RequestLoggingMiddleware",
     "learningplatform_backend.middleware.middleware.DebugLoggingMiddleware",
 ]


### PR DESCRIPTION
## Summary
- clean up `MIDDLEWARE` list
- remove broken middleware comment

## Testing
- `python -m py_compile learningplatform_backend/settings.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_685026a92bc8832cb8ecda2fb97e33ed