### PR TITLE
Fix comment in permissions import

### DIFF
--- a/learningplatform_backend/core/permissions.py
+++ b/learningplatform_backend/core/permissions.py
@@ -3,7 +3,7 @@ import logging  # Add logging import
 from rest_framework.permissions import BasePermission
 
 from .models import \
-    CourseEnrollment  # Replace 'your_app' with the actual app name
+    CourseEnrollment
 
 # Configure logger for this module
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- remove outdated comment about app name

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68502989ae8c832c83bc11379dba13f7