### PR TITLE
Fix login test helper name

### DIFF
--- a/learningplatform_backend/test_login.py
+++ b/learningplatform_backend/test_login.py
@@ -80,7 +80,7 @@ def test_login(username, password):
 def check_health():
     """Test the health endpoint"""
     print("\nChecking server health endpoint...")
-    response = test_endpoint("http://localhost:8000/health/")
+    response = _test_endpoint("http://localhost:8000/health/")
     if response:
         try:
             result = json.loads(response)
@@ -94,7 +94,7 @@ def check_health():
 def check_api_root():
     """Test the API root to discover available endpoints"""
     print("\nChecking API root...")
-    response = test_endpoint("http://localhost:8000/api/v1/")
+    response = _test_endpoint("http://localhost:8000/api/v1/")
     if response:
         try:
             result = json.loads(response)


### PR DESCRIPTION
## Summary
- fix login test helper calls

## Testing
- `python learningplatform_backend/test_login.py testuser testpass` *(fails to login but no NameError)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_6850297b16c4832c9520891b9395fb88