### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  backend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - run: pip install -r learningplatform_backend/requirements.txt
+      - run: pytest
+        working-directory: learningplatform_backend
+
+  frontend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm ci
+        working-directory: frontend
+      - run: npm run test:ci
+        working-directory: frontend


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to run backend and frontend tests on pushes and PRs

## Testing
- `pytest learningplatform_backend` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install -r learningplatform_backend/requirements.txt` *(fails: Could not find a version that satisfies the requirement django==4.2.9)*
- `npm ci --prefix frontend` *(fails: cannot connect to registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68502c5aa42c832c875e74936c317c46