### PR TITLE
Add backend startup to CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:15
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U postgres"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Install backend dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r learningplatform_backend/requirements.txt
+
+      - name: Run migrations
+        run: |
+          python learningplatform_backend/manage.py migrate
+
+      - name: Start backend
+        run: |
+          python learningplatform_backend/manage.py runserver 0.0.0.0:8000 &
+      - name: Wait for backend
+        run: |
+          until curl -s http://localhost:8000/health/; do
+            echo "Waiting for backend..."
+            sleep 2
+          done
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install frontend dependencies
+        run: |
+          cd frontend
+          npm ci
+
+      - name: Run integration tests
+        run: |
+          cd frontend
+          npm run test:integration


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to start the Django backend before running integration tests

## Testing
- `pytest -q learningplatform_backend/tests/test_models.py` *(fails: ModuleNotFoundError: No module named 'core')*
- `npm run test:integration` *(fails: `vitest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68502ebc4ed4832c9db048e50513b9e5